### PR TITLE
Incorrect work of `@Named` annotation 

### DIFF
--- a/bootique-jersey-jakarta/src/main/java/io/bootique/jersey/BaseBqHk2Bridge.java
+++ b/bootique-jersey-jakarta/src/main/java/io/bootique/jersey/BaseBqHk2Bridge.java
@@ -4,6 +4,7 @@ import io.bootique.BootiqueException;
 import io.bootique.di.Injector;
 import io.bootique.di.Key;
 import io.bootique.di.TypeLiteral;
+import jakarta.inject.Named;
 import org.glassfish.hk2.api.Injectee;
 
 import javax.inject.Provider;
@@ -35,15 +36,22 @@ abstract class BaseBqHk2Bridge {
         Annotation bindingAnnotation = injectee.getRequiredQualifiers().isEmpty()
                 ? null
                 : injectee.getRequiredQualifiers().iterator().next();
-        Key<?> key = bindingAnnotation == null
-                ? Key.get(typeLiteral)
-                : Key.get(typeLiteral, bindingAnnotation);
-
+        Key<?> key = getKey(typeLiteral, bindingAnnotation);
         if(!injector.hasProvider(key) && !allowDynamicInjectionForKey(injectee, key)) {
             return null;
         }
 
-        return injector.getProvider(key);
+        return injector. getProvider(key);
+    }
+
+    private Key<?> getKey(TypeLiteral<?> typeLiteral, Annotation bindingAnnotation) {
+        if (bindingAnnotation instanceof Named) {
+           return Key.get(typeLiteral, ((Named) bindingAnnotation).value());
+        } else {
+            return bindingAnnotation == null
+                    ? Key.get(typeLiteral)
+                    : Key.get(typeLiteral, bindingAnnotation);
+        }
     }
 
     /**

--- a/bootique-jersey-jakarta/src/main/java/io/bootique/jersey/BqInjectorBridge.java
+++ b/bootique-jersey-jakarta/src/main/java/io/bootique/jersey/BqInjectorBridge.java
@@ -96,7 +96,7 @@ public class BqInjectorBridge extends BaseBqHk2Bridge implements JustInTimeInjec
 			super(
 					Collections.singleton(implType),
 					jakarta.inject.Singleton.class,
-					null,
+					name(qualifiers),
 					qualifiers,
 					DescriptorType.CLASS,
 					DescriptorVisibility.NORMAL,
@@ -110,6 +110,18 @@ public class BqInjectorBridge extends BaseBqHk2Bridge implements JustInTimeInjec
 			this.implType = implType;
 			this.implClass = implClass;
 			setImplementation(implClass.getName());
+		}
+
+		// special case for @Named annotation
+		private static String name (Set<Annotation> qualifiers){
+			for (Annotation qualifier : qualifiers) {
+				if(qualifier instanceof jakarta.inject.Named) {
+					return ((jakarta.inject.Named) qualifier).value();
+				} else if(qualifier instanceof javax.inject.Named) {
+					return ((javax.inject.Named) qualifier).value();
+				}
+			}
+			return null;
 		}
 
 		public BqBindingActiveDescriptor() {

--- a/bootique-jersey/src/main/java/io/bootique/jersey/BqInjectorBridge.java
+++ b/bootique-jersey/src/main/java/io/bootique/jersey/BqInjectorBridge.java
@@ -27,6 +27,7 @@ import org.glassfish.hk2.utilities.AbstractActiveDescriptor;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.lang.annotation.Annotation;
@@ -98,7 +99,7 @@ public class BqInjectorBridge extends BaseBqHk2Bridge implements JustInTimeInjec
 			super(
 					Collections.singleton(implType),
 					Singleton.class,
-					null,
+					name(qualifiers),
 					qualifiers,
 					DescriptorType.CLASS,
 					DescriptorVisibility.NORMAL,
@@ -112,6 +113,16 @@ public class BqInjectorBridge extends BaseBqHk2Bridge implements JustInTimeInjec
 			this.implType = implType;
 			this.implClass = implClass;
 			setImplementation(implClass.getName());
+		}
+
+		private static String name (Set<Annotation> qualifiers){
+			for (Annotation qualifier : qualifiers) {
+				if(qualifier instanceof Named) {
+					// special case for @Named annotation
+					return ((Named) qualifier).value();
+				}
+			}
+			return null;
 		}
 
 		public BqBindingActiveDescriptor() {

--- a/bootique-jersey/src/test/java/io/bootique/jersey/ResourceInjectionIT.java
+++ b/bootique-jersey/src/test/java/io/bootique/jersey/ResourceInjectionIT.java
@@ -21,7 +21,6 @@ package io.bootique.jersey;
 
 import io.bootique.BQRuntime;
 import io.bootique.Bootique;
-import io.bootique.di.BQInject;
 import io.bootique.jetty.junit5.JettyTester;
 import io.bootique.junit5.BQApp;
 import io.bootique.junit5.BQTest;
@@ -40,6 +39,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @BQTest
@@ -57,7 +57,7 @@ public class ResourceInjectionIT {
             .autoLoadModules()
             .module(b -> b.bind(InjectedService.class).toInstance(service))
             .module(b -> b.bind(InjectedServiceInterface.class, "A").toInstance(serviceA))
-            .module(b -> b.bind(InjectedServiceInterface.class, "B").toInstance(serviceB))
+            .module(b -> b.bind(InjectedServiceInterface.class, ServiceBQualifier.class).toInstance(serviceB))
             .module(b -> b.bind(UnInjectedResource.class).toProviderInstance(() -> new UnInjectedResource(service)))
             .module(b -> JerseyModule.extend(b)
                     .addFeature(ctx -> {
@@ -157,7 +157,7 @@ public class ResourceInjectionIT {
         private InjectedServiceInterface serviceA;
 
         @Inject
-        @Named("B")
+        @ServiceBQualifier
         private InjectedServiceInterface serviceB;
 
         @Context
@@ -250,5 +250,11 @@ public class ResourceInjectionIT {
         public int getNext() {
             return atomicInt.incrementAndGet();
         }
+    }
+
+    @java.lang.annotation.Documented
+    @java.lang.annotation.Retention(RUNTIME)
+    @javax.inject.Qualifier
+    public @interface ServiceBQualifier {
     }
 }


### PR DESCRIPTION
Solution for work of `@Named` annotation in bootique-jersey module.
Partialy solution for work of `@Named` annotation in bootique-jersey-jakarta module. Tests for unsolved issues added.

See #82 

**That combinations works well in jersey-jakarta;**
```
@jakarta.inject.Inject
@jakarta.inject.Named("")
```

and 

```
@jakarta.inject.Inject
@jakarta.inject.Qualifier
```

**There's a problem with. Added tests for this cases:**

```
 @javax.inject.Inject
 @javax.injectNamed("")
 
 @BQInject
 @javax.injectNamed("")
 
 @lavax.inject.Inject
 @javax.inject.Qualifier
 ```